### PR TITLE
Add flake.nix with python and packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1656502645,
+        "narHash": "sha256-Xzs4CyLQhLaWl+2ANjM+JAO7JK3ANI+vxI/hVbjwU20=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "13d3fc8f69ec1c6c5462406cde8ad4a7e01c0414",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = inputs:
+    inputs.flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = inputs.nixpkgs.legacyPackages.${system};
+        my-python = pkgs.python3;
+        python-with-my-packages = my-python.withPackages (p: with p; [
+          wheel
+          requests
+          # other python packages you want
+        ]);
+      in
+      {
+        devShell =
+          pkgs.mkShell
+            {
+              buildInputs = [
+                python-with-my-packages
+              ];
+              shellHook = ''
+                PYTHONPATH=${python-with-my-packages}/${python-with-my-packages.sitePackages}
+                # maybe set more env-vars
+              '';
+            };
+      }
+    );
+}
+


### PR DESCRIPTION
This PR adds flake.nix with a devshell definition that contains python3 together with `requests` and `wheel` modules.

Type `nix develop` to enter the devshell

You didn't think I would have installed python globally on my machine, did you? :D 