### PR TITLE
improve register

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Toolbox for various cardano related operations.
 Installation with python virtual environment:
 1. Install Python3: sudo apt install python3
 2. Install pip for python3: sudo apt-get install build-essential libssl-dev libffi-dev python-dev / sudo apt install python3-pip
-3. Optional: Install venv for python3: sudo pip3 install virtualenv 
+3. Optional: Install venv for python3: sudo pip3 install virtualenv
 4. Optional: python3 -m venv venv
 5. Optional: source venv/bin/activate
 6. pip install --upgrade pip
@@ -69,3 +69,17 @@ To send multiple tokens to a destination:
                           --token-policy-id [Space separated list of token policies]
                           --token-amount [Space separated list of amounts per token policy ID]
                           --network <mainnet or testnet-magic NNNN etc>
+
+## Examples:
+
+### Register a new SPO:
+
+In an empty folder run:
+
+```
+python3 /path/to/registerSPO.py \
+  --funding-addr-file /path/to/payment.addr \
+  --funding-skey-file /path/to/payment.skey \
+  --network 'testnet-magic 7' \
+  --name "MY-SPO-NAME" --ticker 'AAAA'
+```

--- a/cardano_cli_helper.py
+++ b/cardano_cli_helper.py
@@ -32,8 +32,8 @@ def getCardanoCliValue(command, key):
         stderr = stderr.decode("utf-8")
         print(stdout)
         print(stderr)
-        if not stderr == '':
-            return (-1)
+        if process.returncode != 0:
+            raise Exception(f'Error calling {command}')
     if not key == '':
         try:
             result = json.loads(stdout)[key]

--- a/registerSPO.py
+++ b/registerSPO.py
@@ -57,6 +57,7 @@ def main(fundingAddrFile, fundingSkeyFile, poolName, poolTicker, homepage, fund_
 
     # Fund newly created account
     # TODO: Verify the funding account has enough funds
+    print(f'funding address {paymentAddr}')
     sendADA.main(fundingAddrFile,
                  fundingSkeyFile,
                  os.path.join(working_folder, 'payment.addr'),
@@ -66,16 +67,16 @@ def main(fundingAddrFile, fundingSkeyFile, poolName, poolTicker, homepage, fund_
     while lovelace == -1:
         print('Waiting for Tx to get on the blockchain')
         time.sleep(5)
-        lovelace, utxos = cli.getLovelaceBalance(paymentAddr, network)
+        lovelace, utxos = cli.getLovelaceBalance(paymentAddr, network, onlyAda=True)
     ttlSlot = cli.queryTip('slot', network) + 1000
-    cli.buildRegisterCertTx(utxos[0], ttlSlot, min_amount, network)
+    cli.buildRegisterCertTx(utxos, ttlSlot, min_amount, network)
     cli.signTx([paymentSkeyFile, 'stake.skey'], network=network)
     cli.submitSignedTx(network=network)
     newLovelace = lovelace
     while lovelace == newLovelace:
         print('Waiting for Tx to get on the blockchain')
         time.sleep(5)
-        newLovelace, utxos = cli.getLovelaceBalance(paymentAddr, network)
+        newLovelace, utxos = cli.getLovelaceBalance(paymentAddr, network, onlyAda=True)
     cli.generateVRFKeyPair()
     cli.generateColdKeys()
     cli.generateKESKeyPair()
@@ -91,16 +92,16 @@ def main(fundingAddrFile, fundingSkeyFile, poolName, poolTicker, homepage, fund_
     cli.generateStakePoolRegistrationCertificate(pledge_amount, pool_ip, metadataURL, metadataHash, network=network)
     cli.generateDelegationCertificatePledge()
     print('Generated delegation certificate pledge')
-    lovelace, utxos = cli.getLovelaceBalance(paymentAddr, network)
+    lovelace, utxos = cli.getLovelaceBalance(paymentAddr, network, onlyAda=True)
     ttlSlot = cli.queryTip('slot', network) + 1000
-    cli.buildPoolAndDelegationCertTx(utxos[0], ttlSlot, min_amount, network)
+    cli.buildPoolAndDelegationCertTx(utxos, ttlSlot, min_amount, network)
     cli.signTx(['payment.skey', 'stake.skey', 'cold.skey'], network=network)
     cli.submitSignedTx(network=network)
     newLovelace = lovelace
     while lovelace == newLovelace:
         print('Waiting for Tx to get on the blockchain')
         time.sleep(5)
-        newLovelace, utxos = cli.getLovelaceBalance(paymentAddr, network)
+        newLovelace, utxos = cli.getLovelaceBalance(paymentAddr, network, onlyAda=True)
     poolId = cli.getPoolId().strip()
     print('Pool registered:', cli.verifyPoolIsRegistered(poolId, network))
 

--- a/sendADA.py
+++ b/sendADA.py
@@ -18,13 +18,10 @@ def main(paymentAddrFile, paymentSkeyFile, recipientAddr, lovelace_amount, netwo
 
     lovelace = -1
     while lovelace == -1:
-        lovelace, utxos = cli.getLovelaceBalance(paymentAddr, network)
+        lovelace, utxos = cli.getLovelaceBalance(paymentAddr, network, onlyAda=True)
         time.sleep(5)
     ttlSlot = cli.queryTip('slot', network) + 1000
-    cli.getDraftTXSimple(utxos, paymentAddr, recipientAddr, ttlSlot)
-    minFee = cli.getMinFee(len(utxos),1, network)
-    lovelace_return = lovelace - minFee - lovelace_amount
-    cli.getRawTxSimple(utxos,paymentAddr,recipientAddr, lovelace_amount, lovelace_return, ttlSlot, minFee)
+    cli.getRawTxSimple(utxos, paymentAddr, recipientAddr, lovelace_amount, ttlSlot, network=network)
     cli.signTx([paymentSkeyFile], network=network)
     cli.submitSignedTx(network=network)
 


### PR DESCRIPTION
This brings a few changes we can discuss: 

 - raise an exception when a command does not return a success code: otherwise the registration would continue running indefinitely even in case of error
 - add an option to ignore non ada utxos: the reason is that non ada tokan are not handled by the cardano cli correctly (they are not balanced) so it's a bit cumbersome to handle. It was easier to just ignure those utxo
 - `getRawTxSimple` use `transaction build` instead of build-raw
 - some function that took one input now use a list of inputs: it tool the first utxo but for some reason the first utxo was too small