### PR TITLE
fix: limit utxo number for tx_in to fit tx in a block

### DIFF
--- a/cardano_cli_helper.py
+++ b/cardano_cli_helper.py
@@ -2,6 +2,7 @@ import json
 from subprocess import PIPE, Popen
 from os.path import exists
 from datetime import datetime
+from itertools import islice
 import os
 import time
 
@@ -69,7 +70,7 @@ def getStakeBalance(stake_addr, network="mainnet"):
     return res[0]['rewardAccountBalance']
 
 
-def getAddrUTxOs(addr, network="mainnet", onlyAda=False):
+def getAddrUTxOs(addr, network="mainnet", utxoLimit = 0, onlyAda=False):
     print('Getting address transactions...')
     outfile = 'utxos.json'
     command = f'cardano-cli query utxo --address {addr} \
@@ -77,6 +78,8 @@ def getAddrUTxOs(addr, network="mainnet", onlyAda=False):
     if getCardanoCliValue(command, '') != -1:
         file = open(outfile)
         utxosJson = json.load(file)
+        if utxoLimit > 0:
+            utxosJson = dict(islice(utxosJson.items(), utxoLimit))
         file.close()
         os.remove(outfile)
         if onlyAda:
@@ -550,9 +553,7 @@ def buildSendTokensToOneDestinationTx(
                     --witness-override 2 '
     i = 1
     for txIn in txInList:
-        i = i + 1
-        if i < 400:  # Make sure it fits in one tx
-            command_build += f'--tx-in {txIn} '
+        command_build += f'--tx-in {txIn} '
     command_tx_out_destination = f'--tx-out {destination}+'
     command_tokens_destination = ""
     for token in sendDict:

--- a/cardano_cli_helper.py
+++ b/cardano_cli_helper.py
@@ -6,6 +6,7 @@ from itertools import islice
 import os
 import time
 
+# CARDANO_CLI_PATH = '/home/christos/.local/bin/8.7.3/'
 CARDANO_CLI_PATH = ''
 
 
@@ -564,7 +565,8 @@ def buildSendTokensToOneDestinationTx(
         lovelace_amount_to_send = getMinRequiredUtxo(
             era,
             command_tx_out_destination + "99999999"
-            + command_tokens_destination
+            + command_tokens_destination,
+            network
             )
     else:
         lovelace_amount_to_send = str(lovelace_amount_to_send)
@@ -584,7 +586,8 @@ def buildSendTokensToOneDestinationTx(
         lovelace_for_txout_return_tokens = getMinRequiredUtxo(
             era,
             command_return_lovelace + "99999999"
-            + command_return_tokens
+            + command_return_tokens,
+            network
             )
 
     command_change_address = f' --change-address {change_address} \
@@ -637,9 +640,9 @@ def getSenderAddressFromSimpleTxHash(txHash_txIx: str, network):
     return getCardanoCliValue(command, '')
 
 
-def getMinRequiredUtxo(era, txout):
+def getMinRequiredUtxo(era, txout, network):
     print("Getting min required amount of lovelace for tx-out...")
-    getProtocolJson(network='testnet-magic 7')
+    getProtocolJson(network=network)
     command = f"cardano-cli transaction calculate-min-required-utxo \
                 --protocol-params-file protocol.json \
                 --{era} \

--- a/cleanAddress.py
+++ b/cleanAddress.py
@@ -20,7 +20,9 @@ def main(paymentAddrFile, paymentSkeyFile, garbageAddrFile,
     else:
         garbageAddr = garbageAddrFile.strip()
 
-    utxos = cli.getAddrUTxOs(paymentAddr, network)
+    utxo_limit = 200 # Ensures that the tx can fit in a block
+    # TODO: The number should be better calculated in bytes though
+    utxos = cli.getAddrUTxOs(paymentAddr, network, utxo_limit)
     dictWallet = cli.getTokenListFromTxHash(utxos)
     ttlSlot = cli.queryTip('slot', network) + 1000
 
@@ -38,7 +40,7 @@ def main(paymentAddrFile, paymentSkeyFile, garbageAddrFile,
         )
     cli.signTx([paymentSkeyFile], network=network)
 
-    cli.submitSignedTx(network=network)
+    print(cli.submitSignedTx(network=network))
 
 
 if __name__ == '__main__':

--- a/sendTokens.py
+++ b/sendTokens.py
@@ -24,7 +24,8 @@ def main(paymentAddrFile, paymentSkeyFile, recipientAddr, lovelace_amount,
     for tokenID, tokenAmount in zip(policyIDList, tokenAmountList):
         sendTokensDict[tokenID] = tokenAmount
 
-    utxos = cli.getAddrUTxOs(paymentAddr, network)
+    utxos_limit = 200  # Ensures that the tx can fit in a block
+    utxos = cli.getAddrUTxOs(paymentAddr, network, utxos_limit)
     dictWallet = cli.getTokenListFromTxHash(utxos)
 
     try:


### PR DESCRIPTION
If an address contains a huge number of UTxOs then limit the amount of UTxOs inserted into the utxo dictionary. This way you can clean an address iteratively without running into the issue of trying to balance tokens that are not in the tx_in list.